### PR TITLE
docs: alias, direnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@
 export AQUA_GLOBAL_CONFIG="$HOME/.config/aqua/aqua.yaml"
 export PATH="$(aqua root-dir)/bin:$PATH"
 ```
+
+## alias
+
+```bash
+alias aq='aqua'
+alias aqgi='aqua generate -i -o $AQUA_GLOBAL_CONFIG'
+alias aqia='aqua install --all'
+alias aqli='aqua list --installed --all | sort'
+alias aqup='aqua update'
+```

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -8,7 +8,7 @@
 #   - all
 registries:
 - type: standard
-  ref: v4.185.1 # renovate: depName=aquaproj/aqua-registry
+  ref: v4.186.0 # renovate: depName=aquaproj/aqua-registry
 packages:
 - name: cli/cli@v2.49.2
   desc: GitHub CLI
@@ -27,7 +27,7 @@ packages:
 - name: aws/aws-cli@2.15.58
 - name: 99designs/aws-vault@v7.2.0
 - name: charmbracelet/glow@v1.5.1
-- name: kayac/ecspresso@v2.3.4
+- name: kayac/ecspresso@v2.3.3
 - name: ericchiang/pup@v0.4.0
 - name: tfutils/tfenv@v3.0.0
 - name: terraform-linters/tflint@v0.51.1


### PR DESCRIPTION
README に alias をメモ

```bash
aqua $ aqup
INFO[0020] updating a package                            aqua_version=2.27.3 env=linux/amd64 new_version=v2.3.3 old_version=v2.3.4 package_name=kayac/ecspresso program=aqua
INFO[0020] updating a registry                           aqua_version=2.27.3 env=linux/amd64 new_version=v4.186.0 old_version=v4.185.1 program=aqua registry_name=standard
aqua $ aqia
aqua $ aqli
99designs/aws-vault     v7.2.0  standard
ahmetb/kubectl-tree     v0.4.3  standard
ahmetb/kubectx  v0.9.5  standard
ahmetb/kubectx/kubens   v0.9.5  standard
astral-sh/rye   0.34.0  standard
aws/aws-cli     2.15.58 standard
charmbracelet/glow      v1.5.1  standard
cli/cli v2.49.2 standard
derailed/k9s    v0.32.4 standard
direnv/direnv   v2.34.0 standard
ericchiang/pup  v0.4.0  standard
golang/go       go1.22.3        standard
google/yamlfmt  v0.12.1 standard
hashicorp/levant        v0.3.3  standard
hashicorp/packer        v1.10.3 standard
helm/helm       v3.15.1 standard
jqlang/jq       jq-1.7.1        standard
kayac/ecspresso v2.3.3  standard
kubecolor/kubecolor     v0.3.3  standard
kubernetes-sigs/kind    v0.23.0 standard
kubernetes-sigs/krew    v0.4.4  standard
kubernetes-sigs/kustomize       kustomize/v5.4.2        standard
kubernetes/kubeadm      v1.30.1 standard
kubernetes/kubectl      v1.30.1 standard
mikefarah/yq    v4.44.1 standard
nektos/act      v0.2.62 standard
stateful/runme  v3.3.1  standard
stern/stern     v1.30.0 standard
terraform-linters/tflint        v0.51.1 standard
tfutils/tfenv   v3.0.0  standard
volta-cli/volta v1.1.1  standard
aqua $
```

作業例として実行してみたんだけどなぜか ecspresso がダウングレードした？